### PR TITLE
Add logistic regression example and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/
+
+# Model files
+*.joblib

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
-# 데이터분석전문가 실기 준비를 위한 정리
+# Data Science Study Repository
 
-- `all_ml.ipynb`: 머신러닝 파트 통합 정리 파일
-- `all_statistics.ipynb`: 통계분석 파 통합 정리 파일
-- `nlp.ipynb`: 자연어 처리 대비용 파일
-- `final.ipynb`: 위 파일들을 통합한 파일
+This repository contains notebooks and example scripts used to prepare for the ADP/Data Scientist exam.
+
+## Notebooks
+- `all_ml.ipynb`: consolidated machine learning notes
+- `all_statistics.ipynb`: consolidated statistics notes
+- `nlp.ipynb`: natural language processing notes
+- `final.ipynb`: combined notebook of all topics
+
+## Scripts
+- `src/train_logistic_regression.py`: simple example of training a logistic regression model on the Iris dataset. The trained model is saved as `iris_log_reg.joblib`.
+
+## Setup
+Install dependencies using:
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+Run the example training script with:
+```bash
+python src/train_logistic_regression.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scikit-learn
 matplotlib
 plotly
 mglearn
+joblib

--- a/src/train_logistic_regression.py
+++ b/src/train_logistic_regression.py
@@ -1,0 +1,40 @@
+import joblib
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+
+
+def load_data():
+    """Load Iris dataset."""
+    data = load_iris()
+    return data.data, data.target
+
+
+def train_model(X_train, y_train):
+    """Train logistic regression model."""
+    model = LogisticRegression(max_iter=200)
+    model.fit(X_train, y_train)
+    return model
+
+
+def evaluate_model(model, X_test, y_test):
+    """Evaluate model accuracy."""
+    preds = model.predict(X_test)
+    acc = accuracy_score(y_test, preds)
+    print(f"Accuracy: {acc:.4f}")
+    return acc
+
+
+def main():
+    X, y = load_data()
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42, stratify=y
+    )
+    model = train_model(X_train, y_train)
+    evaluate_model(model, X_test, y_test)
+    joblib.dump(model, "iris_log_reg.joblib")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new logistic regression training script in `src`
- document setup and script usage in README
- track generated models via `.gitignore`
- update `requirements.txt` with joblib

## Testing
- `python -m py_compile src/train_logistic_regression.py`

------
https://chatgpt.com/codex/tasks/task_e_683fba8d28988333b4cac39c25546100